### PR TITLE
Remove unhelpful murder threat

### DIFF
--- a/sop.md
+++ b/sop.md
@@ -40,7 +40,7 @@ Subject to the approval by the IETF Chair, the Moderators team member also infor
 
 ### Immediate escalation in egregious cases
 
-In cases where postings contain egregious language, the Moderators team has the discretion to skip level 0 and go straight to level 1 or 2. For example, a posting that says "I'm coming to murder you and your family" would warrant an immediate escalation to level 2.
+In cases where postings contain egregious language, the Moderators team has the discretion to skip level 0 and go straight to level 1 or 2.
 
 ## Finding a more specific forum
 


### PR DESCRIPTION
The current SOP gives moderators the ability to go immediately to level 2. The following sentence I think is trying to be helpful in giving an example when that would be appropriate. However the example given is "I'm coming to murder you and your family", which is extreme.

In practice I find the only examples that would be useful are ones that are close to the borderline. One option we have is to think of such an example and include it here.

On balance I think it's better to not include an example at all, and leave it to the team's discretion. We still have the appeal process. This PR removes the example.

