### PR TITLE
Remove inappropriate use of "Hi"

### DIFF
--- a/email-templates/announcements.txt
+++ b/email-templates/announcements.txt
@@ -1,4 +1,4 @@
-Hi [NAME],
+[NAME],
 
 I am writing to you on behalf of the Moderators team for ietf@ietf.org. This message has been vetted with others on the Moderators team, which is described in more detail at [1].
 

--- a/email-templates/first-message.txt
+++ b/email-templates/first-message.txt
@@ -1,4 +1,4 @@
-Hi [NAME],
+[NAME],
 
 I am writing to you on behalf of the Moderators team for ietf@ietf.org. This message has been vetted with others on the Moderators team, which is described in more detail at [1] and [2].
 

--- a/email-templates/first-moderation-thread-message.txt
+++ b/email-templates/first-moderation-thread-message.txt
@@ -1,4 +1,4 @@
-Hi [NAME],
+[NAME],
 
 I am writing to you on behalf of the Moderators team for ietf@ietf.org. This message has been vetted with others on the Moderators team, which is described in more detail at [1] and [2].
 

--- a/email-templates/first-pattern-of-abuse-message.txt
+++ b/email-templates/first-pattern-of-abuse-message.txt
@@ -1,4 +1,4 @@
-Hi [NAME],
+[NAME],
 
 I am writing to you on behalf of the Moderators team for ietf@ietf.org. This message has been vetted with others on the Moderators team, which is described in more detail at [1] and [2].
 

--- a/email-templates/out-of-scope.txt
+++ b/email-templates/out-of-scope.txt
@@ -1,5 +1,5 @@
 
-Hi [NAME],
+[NAME],
 
 I am writing to you on behalf of the Moderators team for ietf@ietf.org. This message has been vetted with others on the Moderators team, which is described in more detail at [1].
 

--- a/email-templates/second-moderation-thread-message.txt
+++ b/email-templates/second-moderation-thread-message.txt
@@ -1,4 +1,4 @@
-Hi [NAME],
+[NAME],
 
 I am writing to you on behalf of the Moderators team for ietf@ietf.org. This message has been vetted with others on the Moderators team, which is described in more detail at [1] and [2].
 

--- a/email-templates/second-pattern-of-abuse-message.txt
+++ b/email-templates/second-pattern-of-abuse-message.txt
@@ -1,4 +1,4 @@
-Hi [NAME],
+[NAME],
 
 I am writing to you on behalf of the Moderators team for ietf@ietf.org. This message has been vetted with others on the Moderators team, which is described in more detail at [1] and [2].
 

--- a/email-templates/unsolicited-email.txt
+++ b/email-templates/unsolicited-email.txt
@@ -1,4 +1,4 @@
-Hi [NAME],
+[NAME],
 
 I am writing to you on behalf of the Moderators team for ietf@ietf.org. This message has been vetted with others on the Moderators team, which is described in more detail at [1].
 


### PR DESCRIPTION
The existing template messages to recipients of moderation actions all begin with "Hi [NAME]".

To me, this starts the message on the wrong foot. It implies that the moderator and the recipients are friends, and they are simply engaging in friendly conversation. This contrasts sharply with the remainder, which is unavoidably delivering an unwelcome message.

I propose to delete the "Hi" from the start of messages to individuals.


